### PR TITLE
Add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     author='Jupyter Development Team',
     author_email='jupyter@googlegroups.com',
     url='https://github.com/jupyter/echo_kernel',
+    install_requires=[
+        'jupyter_client', 'IPython', 'ipykernel'
+    ],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
The `setup.py` file did not contain any installation requirements. This PR adds `jupyter_client`, `IPython` and `ipykernel` to the `install_requires` key, thus ensuring they are available when the package is installed.