### PR TITLE
Removed deprecated argument

### DIFF
--- a/echo_kernel/install.py
+++ b/echo_kernel/install.py
@@ -20,7 +20,7 @@ def install_my_kernel_spec(user=True, prefix=None):
         # TODO: Copy any resources
 
         print('Installing Jupyter kernel spec')
-        KernelSpecManager().install_kernel_spec(td, 'echo', user=user, replace=True, prefix=prefix)
+        KernelSpecManager().install_kernel_spec(td, 'echo', user=user, prefix=prefix)
 
 def _is_root():
     try:


### PR DESCRIPTION
'replace' is deprecated. Installing a kernelspec always replaces an existing installation.